### PR TITLE
Remove dates from all pages

### DIFF
--- a/01.getting-started/01.glossary/article.md
+++ b/01.getting-started/01.glossary/article.md
@@ -1,6 +1,5 @@
 ---
 title: Glossary
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - 'Getting Started'

--- a/01.getting-started/article.md
+++ b/01.getting-started/article.md
@@ -1,6 +1,5 @@
 ---
 title: 'Getting Started'
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - 'Getting Started'

--- a/02.pivx-core-wallet/01.installing-the-pivx-core-wallet/article.md
+++ b/02.pivx-core-wallet/01.installing-the-pivx-core-wallet/article.md
@@ -1,6 +1,5 @@
 ---
 title: 'Installing the PIVX Core Wallet'
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - 'PIVX Core Wallet'

--- a/02.pivx-core-wallet/01.installing-the-pivx-core-wallet/install-tabs/tabs.md
+++ b/02.pivx-core-wallet/01.installing-the-pivx-core-wallet/install-tabs/tabs.md
@@ -1,6 +1,5 @@
 ---
 title: 'Install Tabs'
-date: '14-10-2021 00:00'
 taxonomy:
     author:
         - 'The PIVX Team'

--- a/02.pivx-core-wallet/02.core-wallet-faq/faq.md
+++ b/02.pivx-core-wallet/02.core-wallet-faq/faq.md
@@ -1,6 +1,5 @@
 ---
 title: 'Core Wallet Best Practices / FAQ'
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - 'PIVX Core Wallet'

--- a/02.pivx-core-wallet/03.qt-wallet/article.md
+++ b/02.pivx-core-wallet/03.qt-wallet/article.md
@@ -1,6 +1,5 @@
 ---
 title: 'PIVX QT Core Wallet'
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - 'PIVX Core Wallet'

--- a/02.pivx-core-wallet/03.qt-wallet/qt-wallet-tabs/tabs.md
+++ b/02.pivx-core-wallet/03.qt-wallet/qt-wallet-tabs/tabs.md
@@ -1,6 +1,5 @@
 ---
 title: 'QT Wallet Tabs'
-date: '14-10-2021 00:00'
 taxonomy:
     author:
         - 'The PIVX Team'

--- a/02.pivx-core-wallet/04.command-line-core-wallet/article.md
+++ b/02.pivx-core-wallet/04.command-line-core-wallet/article.md
@@ -1,6 +1,6 @@
 ---
 title: 'PIVX Command Line Core Wallet'
-date: '14-10-2021 00:00'
+
 taxonomy:
     category:
         - 'PIVX Core Wallet'

--- a/02.pivx-core-wallet/05.rpc-client/article.md
+++ b/02.pivx-core-wallet/05.rpc-client/article.md
@@ -1,6 +1,5 @@
 ---
 title: 'RPC Client'
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - 'PIVX Core Wallet'

--- a/02.pivx-core-wallet/06.wallet-debugging-features/article.md
+++ b/02.pivx-core-wallet/06.wallet-debugging-features/article.md
@@ -1,6 +1,5 @@
 ---
 title: 'PIVX Core Wallet Debugging Features'
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - 'PIVX Core Wallet'

--- a/02.pivx-core-wallet/article.md
+++ b/02.pivx-core-wallet/article.md
@@ -1,6 +1,5 @@
 ---
 title: 'PIVX Core Wallet'
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - 'PIVX Core Wallet'

--- a/03.mobile-hardware-wallets/01.cold-staking-ledger/article.md
+++ b/03.mobile-hardware-wallets/01.cold-staking-ledger/article.md
@@ -1,6 +1,5 @@
 ---
 title: 'Setup Cold Staking With Ledger Hardware Wallet'
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - 'Mobile Wallets'

--- a/03.mobile-hardware-wallets/02.flits-wallet/_flits-buy-gift-cart/tutorial.md
+++ b/03.mobile-hardware-wallets/02.flits-wallet/_flits-buy-gift-cart/tutorial.md
@@ -1,6 +1,5 @@
 ---
 title: 'Test Wallet'
-date: '14-10-2021 00:00'
 slug: flits-buy-gift-cart
 taxonomy:
     category:

--- a/03.mobile-hardware-wallets/02.flits-wallet/article.md
+++ b/03.mobile-hardware-wallets/02.flits-wallet/article.md
@@ -1,6 +1,5 @@
 ---
 title: 'Buying an Amazon card with the Flits Wallet'
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - 'Mobile Wallets'

--- a/03.mobile-hardware-wallets/article.md
+++ b/03.mobile-hardware-wallets/article.md
@@ -1,6 +1,5 @@
 ---
 title: 'Mobile & Hardware Wallets'
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - 'Mobile Wallets'

--- a/04.staking/01.core-wallet/article.md
+++ b/04.staking/01.core-wallet/article.md
@@ -1,6 +1,5 @@
 ---
 title: 'Staking with PIVX Core Wallet'
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - Staking

--- a/04.staking/02.cold-staking/article.md
+++ b/04.staking/02.cold-staking/article.md
@@ -1,6 +1,5 @@
 ---
 title: 'Cold-Staking your PIV'
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - Staking

--- a/04.staking/03.faq/faq.md
+++ b/04.staking/03.faq/faq.md
@@ -1,6 +1,5 @@
 ---
 title: 'Troubleshooting Staking'
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - Staking

--- a/04.staking/article.md
+++ b/04.staking/article.md
@@ -1,6 +1,5 @@
 ---
 title: Staking
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - Staking

--- a/07.masternodes-and-governance/01.pivx-governance/article.md
+++ b/07.masternodes-and-governance/01.pivx-governance/article.md
@@ -1,6 +1,5 @@
 ---
 title: 'PIVX Governance'
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - 'Masternodes And Governance'

--- a/07.masternodes-and-governance/02.masternodes/article.md
+++ b/07.masternodes-and-governance/02.masternodes/article.md
@@ -1,6 +1,5 @@
 ---
 title: 'General Masternodes'
-date: '17-01-2022 00:00'
 taxonomy:
     category:
         - 'Masternodes And Governance'

--- a/07.masternodes-and-governance/03.hosting-on-digital-ocean/article.md
+++ b/07.masternodes-and-governance/03.hosting-on-digital-ocean/article.md
@@ -1,6 +1,5 @@
 ---
 title: 'Hosting a PIVX Masternode On Digital Ocean '
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - 'Masternodes And Governance'

--- a/07.masternodes-and-governance/04.troubleshooting/faq.md
+++ b/07.masternodes-and-governance/04.troubleshooting/faq.md
@@ -1,6 +1,5 @@
 ---
 title: 'Troubleshooting Masternodes'
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - Masternodes

--- a/07.masternodes-and-governance/article.md
+++ b/07.masternodes-and-governance/article.md
@@ -1,6 +1,5 @@
 ---
 title: 'Masternodes And Governance'
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - 'Masternodes And Governance'

--- a/08.knowledge-base/01.pivx-as-a-service-linux/article.md
+++ b/08.knowledge-base/01.pivx-as-a-service-linux/article.md
@@ -1,7 +1,5 @@
 ---
 title: 'Run PIVX Core Wallet as a service on Linux'
-date: '01-11-2021 00:00'
-description: 'Run PIVX Core Wallet as a service on Linux'
 image: troubleshooting.png
 taxonomy:
     category:

--- a/08.knowledge-base/02.wallet-behind-tor/article.md
+++ b/08.knowledge-base/02.wallet-behind-tor/article.md
@@ -1,6 +1,5 @@
 ---
 title: 'Setting up a PIVX Wallet/Masternode behind Tor'
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - 'Knowledge Base'

--- a/08.knowledge-base/03.best-practices/article.md
+++ b/08.knowledge-base/03.best-practices/article.md
@@ -1,6 +1,5 @@
 ---
 title: 'PIVX Best Practices'
-date: '14-10-2021 00:00'
 taxonomy:
     category:
         - 'Knowledge Base'

--- a/08.knowledge-base/article.md
+++ b/08.knowledge-base/article.md
@@ -1,6 +1,5 @@
 ---
 title: 'Knowledge Base'
-date: '01-11-2021 00:00'
 taxonomy:
     category:
         - 'Knowledge Base'


### PR DESCRIPTION
Page embedded dates are useless!  These dates are not likely to be updated whenever other texts are updated on the page. It's much better to just use the files modified date.  This simplifies the pages YAML frontmatter which in turn results in less mistakes and no need to know the specific date format.